### PR TITLE
Fix OpenStreetMap 403 Forbidden error

### DIFF
--- a/src/main/java/br/edu/infnet/karlaapi/model/clients/OpenStreetMapFeignClient.java
+++ b/src/main/java/br/edu/infnet/karlaapi/model/clients/OpenStreetMapFeignClient.java
@@ -15,6 +15,5 @@ public interface OpenStreetMapFeignClient {
     List<Geolocalizacao> search(@RequestParam("q") String query,
                                 @RequestParam("format") String format,
                                 @RequestParam("limit") int limit,
-                                @RequestParam("email") String email,
                                 @RequestHeader("User-Agent") String userAgent);
 }

--- a/src/main/java/br/edu/infnet/karlaapi/model/clients/OpenStreetMapFeignClient.java
+++ b/src/main/java/br/edu/infnet/karlaapi/model/clients/OpenStreetMapFeignClient.java
@@ -15,5 +15,6 @@ public interface OpenStreetMapFeignClient {
     List<Geolocalizacao> search(@RequestParam("q") String query,
                                 @RequestParam("format") String format,
                                 @RequestParam("limit") int limit,
+                                @RequestParam("email") String email,
                                 @RequestHeader("User-Agent") String userAgent);
 }

--- a/src/main/java/br/edu/infnet/karlaapi/model/service/EnderecoGeorreferenciadoService.java
+++ b/src/main/java/br/edu/infnet/karlaapi/model/service/EnderecoGeorreferenciadoService.java
@@ -19,9 +19,6 @@ public class EnderecoGeorreferenciadoService {
     @Value("${api.openstreetmap.useragent}")
     private String userAgent;
 
-    @Value("${api.openstreetmap.email}")
-    private String email;
-
     //private final GeolocalizacaoFeignClient geolocalizacaoFeignClient;
     private final ViaCepFeignClient viaCepFeignClient;
     private final OpenStreetMapFeignClient openStreetMapFeignClient;
@@ -46,7 +43,7 @@ public class EnderecoGeorreferenciadoService {
 
             if (endereco != null) {
                 String query = endereco.getLogradouro() + ", " + endereco.getLocalidade() + ", " + endereco.getUf();
-                List<Geolocalizacao> geolocalizacoes = openStreetMapFeignClient.search(query, "jsonv2", 10, email, userAgent);
+                List<Geolocalizacao> geolocalizacoes = openStreetMapFeignClient.search(query, "jsonv2", 10, userAgent);
 
                 if (geolocalizacoes != null && !geolocalizacoes.isEmpty()) {
                     Geolocalizacao geolocalizacao = geolocalizacoes.get(0);

--- a/src/main/java/br/edu/infnet/karlaapi/model/service/EnderecoGeorreferenciadoService.java
+++ b/src/main/java/br/edu/infnet/karlaapi/model/service/EnderecoGeorreferenciadoService.java
@@ -39,7 +39,7 @@ public class EnderecoGeorreferenciadoService {
 
             if (endereco != null) {
                 String query = endereco.getLogradouro() + ", " + endereco.getLocalidade() + ", " + endereco.getUf();
-                List<Geolocalizacao> geolocalizacoes = openStreetMapFeignClient.search(query, "jsonv2", 10, "KarlaAPI/1.0 (karla@example.com)");
+                List<Geolocalizacao> geolocalizacoes = openStreetMapFeignClient.search(query, "jsonv2", 10, "KarlaGeoApp-1.0-karla-at-example-dot-com");
 
                 if (geolocalizacoes != null && !geolocalizacoes.isEmpty()) {
                     Geolocalizacao geolocalizacao = geolocalizacoes.get(0);

--- a/src/main/java/br/edu/infnet/karlaapi/model/service/EnderecoGeorreferenciadoService.java
+++ b/src/main/java/br/edu/infnet/karlaapi/model/service/EnderecoGeorreferenciadoService.java
@@ -8,12 +8,19 @@ import br.edu.infnet.karlaapi.model.infraestructure.exceptions.CepNotFoundExcept
 import br.edu.infnet.karlaapi.model.infraestructure.exceptions.ExternalApiException;
 import br.edu.infnet.karlaapi.model.infraestructure.exceptions.InvalidCepException;
 import feign.FeignException;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 
 @Service
 public class EnderecoGeorreferenciadoService {
+
+    @Value("${api.openstreetmap.useragent}")
+    private String userAgent;
+
+    @Value("${api.openstreetmap.email}")
+    private String email;
 
     //private final GeolocalizacaoFeignClient geolocalizacaoFeignClient;
     private final ViaCepFeignClient viaCepFeignClient;
@@ -39,7 +46,7 @@ public class EnderecoGeorreferenciadoService {
 
             if (endereco != null) {
                 String query = endereco.getLogradouro() + ", " + endereco.getLocalidade() + ", " + endereco.getUf();
-                List<Geolocalizacao> geolocalizacoes = openStreetMapFeignClient.search(query, "jsonv2", 10, "KarlaGeoApp-1.0-karla-at-example-dot-com");
+                List<Geolocalizacao> geolocalizacoes = openStreetMapFeignClient.search(query, "jsonv2", 10, email, userAgent);
 
                 if (geolocalizacoes != null && !geolocalizacoes.isEmpty()) {
                     Geolocalizacao geolocalizacao = geolocalizacoes.get(0);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,3 +14,5 @@ server.port=${PORT:8081}
 api.viacep.url=https://viacep.com.br/ws/
 
 api.openstreetmap.url=https://nominatim.openstreetmap.org
+api.openstreetmap.useragent=Infnet-Karla-Georef-App-2026
+api.openstreetmap.email=karla@example.com

--- a/src/test/java/br/edu/infnet/karlaapi/model/service/EnderecoGeorreferenciadoServiceTest.java
+++ b/src/test/java/br/edu/infnet/karlaapi/model/service/EnderecoGeorreferenciadoServiceTest.java
@@ -57,6 +57,6 @@ class EnderecoGeorreferenciadoServiceTest {
         assertNotNull(result);
         assertEquals("-5.918", result.getLatitude());
         assertEquals("-35.275", result.getLongitude());
-        verify(openStreetMapFeignClient).search(contains("Rua Pantanal"), eq("jsonv2"), eq(10), eq("KarlaAPI/1.0 (karla@example.com)"));
+        verify(openStreetMapFeignClient).search(contains("Rua Pantanal"), eq("jsonv2"), eq(10), eq("KarlaGeoApp-1.0-karla-at-example-dot-com"));
     }
 }

--- a/src/test/java/br/edu/infnet/karlaapi/model/service/EnderecoGeorreferenciadoServiceTest.java
+++ b/src/test/java/br/edu/infnet/karlaapi/model/service/EnderecoGeorreferenciadoServiceTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Collections;
 import java.util.List;
@@ -33,6 +34,8 @@ class EnderecoGeorreferenciadoServiceTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
+        ReflectionTestUtils.setField(service, "userAgent", "Infnet-Karla-Georef-App-2026");
+        ReflectionTestUtils.setField(service, "email", "karla@example.com");
     }
 
     @Test
@@ -50,13 +53,13 @@ class EnderecoGeorreferenciadoServiceTest {
         List<Geolocalizacao> geolocalizacoes = Collections.singletonList(geolocalizacao);
 
         when(viaCepFeignClient.findByCep(cep)).thenReturn(endereco);
-        when(openStreetMapFeignClient.search(anyString(), anyString(), anyInt(), anyString())).thenReturn(geolocalizacoes);
+        when(openStreetMapFeignClient.search(anyString(), anyString(), anyInt(), anyString(), anyString())).thenReturn(geolocalizacoes);
 
         EnderecoGeorreferenciado result = service.obterEnderecoGeorreferenciadoPorCep(cep);
 
         assertNotNull(result);
         assertEquals("-5.918", result.getLatitude());
         assertEquals("-35.275", result.getLongitude());
-        verify(openStreetMapFeignClient).search(contains("Rua Pantanal"), eq("jsonv2"), eq(10), eq("KarlaGeoApp-1.0-karla-at-example-dot-com"));
+        verify(openStreetMapFeignClient).search(contains("Rua Pantanal"), eq("jsonv2"), eq(10), eq("karla@example.com"), eq("Infnet-Karla-Georef-App-2026"));
     }
 }

--- a/src/test/java/br/edu/infnet/karlaapi/model/service/EnderecoGeorreferenciadoServiceTest.java
+++ b/src/test/java/br/edu/infnet/karlaapi/model/service/EnderecoGeorreferenciadoServiceTest.java
@@ -35,7 +35,6 @@ class EnderecoGeorreferenciadoServiceTest {
     void setUp() {
         MockitoAnnotations.openMocks(this);
         ReflectionTestUtils.setField(service, "userAgent", "Infnet-Karla-Georef-App-2026");
-        ReflectionTestUtils.setField(service, "email", "karla@example.com");
     }
 
     @Test
@@ -53,13 +52,13 @@ class EnderecoGeorreferenciadoServiceTest {
         List<Geolocalizacao> geolocalizacoes = Collections.singletonList(geolocalizacao);
 
         when(viaCepFeignClient.findByCep(cep)).thenReturn(endereco);
-        when(openStreetMapFeignClient.search(anyString(), anyString(), anyInt(), anyString(), anyString())).thenReturn(geolocalizacoes);
+        when(openStreetMapFeignClient.search(anyString(), anyString(), anyInt(), anyString())).thenReturn(geolocalizacoes);
 
         EnderecoGeorreferenciado result = service.obterEnderecoGeorreferenciadoPorCep(cep);
 
         assertNotNull(result);
         assertEquals("-5.918", result.getLatitude());
         assertEquals("-35.275", result.getLongitude());
-        verify(openStreetMapFeignClient).search(contains("Rua Pantanal"), eq("jsonv2"), eq(10), eq("karla@example.com"), eq("Infnet-Karla-Georef-App-2026"));
+        verify(openStreetMapFeignClient).search(contains("Rua Pantanal"), eq("jsonv2"), eq(10), eq("Infnet-Karla-Georef-App-2026"));
     }
 }


### PR DESCRIPTION
The OpenStreetMap (Nominatim) API was returning a 403 Forbidden error due to the User-Agent string used. This change updates the User-Agent to a unique, non-blocked format that still provides identification as requested by OSM policies. Unit tests were also updated to match the new implementation.

---
*PR created automatically by Jules for task [4561364774748437001](https://jules.google.com/task/4561364774748437001) started by @KarlaAlmeida*